### PR TITLE
Added passing through addressComponents field

### DIFF
--- a/ios/RNGooglePlacesViewController.m
+++ b/ios/RNGooglePlacesViewController.m
@@ -57,7 +57,13 @@
 		        placeData[@"phoneNumber"] = place.phoneNumber;
 		        placeData[@"website"] = place.website.absoluteString;
 		        placeData[@"placeID"] = place.placeID;
-		        
+
+            NSMutableDictionary *addressComponents =[[NSMutableDictionary alloc] init];
+            for( int i=0;i<place.addressComponents.count;i++) {
+              addressComponents[place.addressComponents[i].type] = place.addressComponents[i].name;
+            }
+            placeData[@"addressComponents"] = addressComponents;
+
 		        _resolve(placeData);
 		    }
         } else if (error) {
@@ -91,7 +97,13 @@
         placeData[@"phoneNumber"] = place.phoneNumber;
         placeData[@"website"] = place.website.absoluteString;
         placeData[@"placeID"] = place.placeID;
-        
+
+        NSMutableDictionary *addressComponents =[[NSMutableDictionary alloc] init];
+        for( int i=0;i<place.addressComponents.count;i++) {
+          addressComponents[place.addressComponents[i].type] = place.addressComponents[i].name;
+        }
+        placeData[@"addressComponents"] = addressComponents;
+
         _resolve(placeData);
     }
 }


### PR DESCRIPTION
iOS API do support returning addressComponents (e.g. postal code) separately, not only in form of formatted address. For some applications, when user fills in multi-field form for address, such approach is significantly simpler than parsing the formatted string and trying to guess which part is postal code.

Sadly, Android version of the API does not have this functionality (yet), so only iOS port is done.