### PR TITLE
Fix the app crash when the user hit `select` button before the map load

### DIFF
--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
@@ -96,8 +96,10 @@ public class RNGooglePlacesModule extends ReactContextBaseJavaModule implements 
                 map.putDouble("latitude", place.getLatLng().latitude);
                 map.putDouble("longitude", place.getLatLng().longitude);
                 map.putString("name", place.getName().toString());
-                map.putString("address", place.getAddress().toString());
 
+                if (!TextUtils.isEmpty(place.getAddress())) {
+                    map.putString("address", place.getAddress().toString());
+                }
                 if (!TextUtils.isEmpty(place.getPhoneNumber())) {
                     map.putString("phoneNumber", place.getPhoneNumber().toString());
                 }


### PR DESCRIPTION
Verify if `getAddress` is not empty or null before calling `toString()`