### PR TITLE
Add framework search path

### DIFF
--- a/ios/RNGooglePlaces.xcodeproj/project.pbxproj
+++ b/ios/RNGooglePlaces.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 					"\"${SRCROOT}/../../../ios/Pods/GooglePlacePicker/Frameworks\"",
 					"\"${SRCROOT}/../../../ios/Pods/GoogleMaps/Base/Frameworks\"",
 					"\"${SRCROOT}/../../../ios/Pods/GoogleMaps/Maps/Frameworks\"",
+					"~/Documents/GoogleSDK/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -252,6 +253,7 @@
 					"\"${SRCROOT}/../../../ios/Pods/GooglePlacePicker/Frameworks\"",
 					"\"${SRCROOT}/../../../ios/Pods/GoogleMaps/Base/Frameworks\"",
 					"\"${SRCROOT}/../../../ios/Pods/GoogleMaps/Maps/Frameworks\"",
+					"~/Documents/GoogleSDK/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
When adding manually in iOS, it is easier to keep the SDK files within the Documents directory similar to the Facebook SDK setup, https://developers.facebook.com/docs/ios/getting-started/ (see step 2).

So an additional search path has been added:
~/Documents/GoogleSDK/**