### PR TITLE
Add Android Place Photos Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,11 @@ class RNGooglePlaces {
 		return RNGooglePlacesNative.getCurrentPlace()
 	}
 
+	async getPlacePhotos(placeID) {
+		const photos = await RNGooglePlacesNative.getPlacePhotos(placeID)
+		return photos.map((photo, idx) => ({photoID: idx, ...photo}))
+	}
+
 	async getPlacePhotosMetadata(placeID) {
 		const photos = await RNGooglePlacesNative.getPlacePhotosMetadata(placeID)
 		return photos.map((photo, idx) => ({photoID: idx, ...photo}))


### PR DESCRIPTION
As discussed in https://github.com/tolu360/react-native-google-places/issues/149#issuecomment-400719161 (with some slight modifications), this adds the following Google Place Photo API wrappers for android:

```JavaScript
> RNGooglePlaces.getPlacePhotosMetadata(placeID)
[{
  placeId: '...',
  photoId: '...',
  attributions: '...',
  maxWidth: ...,
  maxHeight: ....
},
...
]
```

```JavaScript
// Same as above, but it saves all the images to disk and returns a uri for each.
> RNGooglePlaces.getPlacePhotos(placeID)
[{
  placeId: '...',
  photoId: '...',
  attributions: '...'
  maxWidth: ...,
  maxHeight: ...,
  uri: 'file://...'
},
...
]
```

```JavaScript
> RNGooglePlaces.getPlacePhoto(placePhotoMeta)
'file://...'
```

```JavaScript
> RNGooglePlaces.getScaledPlacePhoto(placePhotoMeta, height, width)
'file://...'
```
