### PR TITLE
Handle android back button in place picker

### DIFF
--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
@@ -119,6 +119,10 @@ public class RNGooglePlacesModule extends ReactContextBaseJavaModule implements 
                 WritableMap map = propertiesMapForPlace(place);
 
                 resolvePromise(map);
+            } else if (resultCode == Activity.RESULT_CANCELED) {
+                // Indicates that the activity closed before a selection was made. For example if
+                // the user pressed the back button.
+                rejectPromise("E_USER_CANCELED", new Error("Search cancelled"));
             }
         }
 


### PR DESCRIPTION
It was already handled for the `PlaceAutocomplete` but not for the `PlacePicker`.

Use case : I need to cancel a task (in my case a loader) when then user cancels the Place Picker with the android back button. 