### PR TITLE
Use implementation and compileOnly in android dependencies.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,9 +37,9 @@ dependencies {
     def googlePlayServicesVersion = rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
     def androidMapsUtilsVersion   = rootProject.hasProperty('androidMapsUtilsVersion')    ? rootProject.androidMapsUtilsVersion   : DEFAULT_ANDROID_MAPS_UTILS_VERSION
 
-    provided "com.facebook.react:react-native:+"
-    compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
-    compile "com.google.android.gms:play-services-places:$googlePlayServicesVersion"
-    compile "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
-    compile "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"
+    compileOnly "com.facebook.react:react-native:+"
+    implementation "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
+    implementation "com.google.android.gms:play-services-places:$googlePlayServicesVersion"
+    implementation "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
+    implementation "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"
 }


### PR DESCRIPTION
Hi, thanks for creating this plugin - it's really useful.

This pull request fixes the following warnings when syncing in android studio:

- Configuration 'provided' is obsolete and has been replaced with
  'compileOnly'.
- Configuration 'compile' is obsolete and has been replaced with
  'implementation' and 'api'.