### PR TITLE
feat: address_components support for android and ios

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,5 +36,5 @@ android {
 
 dependencies {
     compileOnly "com.facebook.react:react-native:+"
-    implementation 'com.google.android.libraries.places:places:1.0.0'
+    implementation "com.google.android.libraries.places:places:1.1.0"
 }

--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
@@ -33,6 +33,7 @@ import com.google.android.gms.common.api.Status;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.tasks.Task;
 import com.google.android.libraries.places.api.Places;
+import com.google.android.libraries.places.api.model.AddressComponent;
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken;
 import com.google.android.libraries.places.api.model.LocationBias;
 import com.google.android.libraries.places.api.model.LocationRestriction;
@@ -380,6 +381,28 @@ public class RNGooglePlacesModule extends ReactContextBaseJavaModule implements 
                 map.putString("address", place.getAddress());
             } else {
                 map.putString("address", "");
+            }
+        }
+
+        if (selectedFields.contains(Place.Field.ADDRESS_COMPONENTS)) {
+            if (place.getAddressComponents() != null) {
+                List<AddressComponent> items = place.getAddressComponents().asList();
+                WritableNativeArray addressComponents = new WritableNativeArray();
+
+                for (AddressComponent item : items) {
+                    WritableMap addressComponentMap = Arguments.createMap();
+                    addressComponentMap.putArray("types", Arguments.fromList(item.getTypes()));
+                    addressComponentMap.putString("name", item.getName());
+                    addressComponentMap.putString("shortName", item.getShortName());
+
+                    addressComponents.pushMap(addressComponentMap);
+                }
+
+                map.putArray("addressComponents", addressComponents);
+            }
+            else {
+                WritableArray emptyResult = Arguments.createArray();
+                map.putArray("addressComponents", emptyResult);
             }
         }
 

--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesPlaceFieldEnum.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesPlaceFieldEnum.java
@@ -22,7 +22,8 @@ public enum RNGooglePlacesPlaceFieldEnum {
     TYPES(11, "types", Place.Field.TYPES),
     USER_RATINGS_TOTAL(12, "userRatingsTotal", Place.Field.USER_RATINGS_TOTAL),
     VIEWPORT(13, "viewport", Place.Field.VIEWPORT),
-    WEBSITE_URI(14, "website", Place.Field.WEBSITE_URI);
+    WEBSITE_URI(14, "website", Place.Field.WEBSITE_URI),
+    ADDRESS_COMPONENTS(15, "addressComponents", Place.Field.ADDRESS_COMPONENTS);
 
     private final String key;
     private final Place.Field field;
@@ -60,7 +61,8 @@ public enum RNGooglePlacesPlaceFieldEnum {
             case "userRatingsTotal" : fieldId = 12; break;
             case "viewport" : fieldId = 13; break;
             case "website" : fieldId = 14; break;
-            default: fieldId = 15; break;
+            case "addressComponents" : fieldId = 15; break;
+            default: fieldId = 16; break;
         }
 
         RNGooglePlacesPlaceFieldEnum fieldEnum = Indexer.index.get(fieldId);

--- a/ios/NSMutableDictionary+GMSPlace.m
+++ b/ios/NSMutableDictionary+GMSPlace.m
@@ -67,10 +67,16 @@
     }
     
     if (place.addressComponents) {
-        NSMutableDictionary *addressComponents = [[NSMutableDictionary alloc] init];
+        NSMutableArray *addressComponents = [[NSMutableArray alloc] init];
         for( int i=0;i<place.addressComponents.count;i++) {
-            addressComponents[place.addressComponents[i].type] = place.addressComponents[i].name;
+            NSMutableDictionary *addressComponent = [[NSMutableDictionary alloc] init];
+            addressComponent[@"types"] = place.addressComponents[i].types;
+            addressComponent[@"name"] = place.addressComponents[i].name;
+            addressComponent[@"shortName"] = place.addressComponents[i].shortName;
+            
+            [addressComponents addObject:addressComponent];
         }
+        
         placeData[@"addressComponents"] = addressComponents;
     }
 

--- a/ios/RNGooglePlaces.m
+++ b/ios/RNGooglePlaces.m
@@ -239,8 +239,7 @@ RCT_EXPORT_METHOD(getCurrentPlace: (NSArray *)fields
     if ([fields count] == 0 && currentOrFetch) {
         GMSPlaceField placeFields = 0;
         for (NSString *fieldLabel in fieldsMapping) {
-            if ([fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldAddressComponents &&
-                [fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldOpeningHours &&
+            if ([fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldOpeningHours &&
                 [fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldPhoneNumber &&
                 [fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldWebsite) {
                 placeFields |= [fieldsMapping[fieldLabel] integerValue];
@@ -252,8 +251,7 @@ RCT_EXPORT_METHOD(getCurrentPlace: (NSArray *)fields
     if ([fields count] != 0 && currentOrFetch) {
         GMSPlaceField placeFields = 0;
         for (NSString *fieldLabel in fields) {
-            if ([fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldAddressComponents &&
-                [fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldOpeningHours &&
+            if ([fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldOpeningHours &&
                 [fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldPhoneNumber &&
                 [fieldsMapping[fieldLabel] integerValue] != GMSPlaceFieldWebsite) {
                 placeFields |= [fieldsMapping[fieldLabel] integerValue];


### PR DESCRIPTION
I needed this functionality for my own app so I decided to add it.

`type` appears to be non-standard and only available on ios so to keep the returned results consistent across platforms I only took `types` (array of String).