### PR TITLE
Fix addressComponents type declaraction in GMSTypes.Place

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -156,7 +156,7 @@ declare module "react-native-google-places" {
        * Address components. If you need the full address, consider using
        * `address` instead.
        */
-      addressComponents: AddressComponent;
+      addressComponents: Array<AddressComponent>;
     }
 
     /**


### PR DESCRIPTION
There seems to be a small mistake in the type declaration of addressComponents in GMSTypes.Place. 

It was being typed as a single AddressComponent instead of an array.