### PR TITLE
Allow jetifier to work with this package

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ android {
 dependencies {
     def supportLibVersion = safeExtGet('supportLibVersion', DEFAULT_SUPPORT_LIB_VERSION)
 
-    compileOnly "com.facebook.react:react-native:+"
+    implementation "com.facebook.react:react-native:+"
     implementation "com.google.android.libraries.places:places:1.1.0"
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
     implementation "com.android.support:support-v4:${supportLibVersion}"


### PR DESCRIPTION
Currently using jetifier for Android 0.60 fails with this package. I don't understand the internals of it, but copied from https://github.com/react-native-community/react-native-maps/pull/2941

This will allow people who are on 0.60 to continue to use this package without updating the package itself to androidx just yet