### PR TITLE
Upgraded google places and maps dependencies to 3.2.0

### DIFF
--- a/react-native-google-places.podspec
+++ b/react-native-google-places.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DHAVE_GOOGLE_MAPS=1', '-fno-modules'
 
   s.dependency 'React'
-  s.dependency 'GooglePlaces', '~> 3.1.0'
-  s.dependency 'GoogleMaps', '~> 3.1.0'
+  s.dependency 'GooglePlaces', '~> 3.2.0'
+  s.dependency 'GoogleMaps', '~> 3.2.0'
 end


### PR DESCRIPTION
With the new release of [react-native-maps](https://github.com/react-native-community/react-native-maps/releases), Google Maps iOS library is now at 3.2.0, which might cause conflicts between `react-native-google-places` and `react-native-maps`

```
[!] CocoaPods could not find compatible versions for pod "GoogleMaps":
  In Podfile:
    react-native-google-maps (from `../node_modules/react-native-maps`) was resolved to 0.26.0, which depends on
      Google-Maps-iOS-Utils (= 2.1.0) was resolved to 2.1.0, which depends on
        GoogleMaps

    react-native-google-maps (from `../node_modules/react-native-maps`) was resolved to 0.26.0, which depends on
      GoogleMaps (= 3.2.0)

    react-native-google-places (from `../node_modules/react-native-google-places`) was resolved to 3.1.2, which depends on
      GoogleMaps (~> 3.1.0)
```