### PR TITLE
Update react-native-google-places.podspec

### DIFF
--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
@@ -8,10 +8,10 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.Manifest.permission;
 import android.content.pm.PackageManager;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
-import android.support.v4.content.ContextCompat;
-import 	android.support.v4.app.ActivityCompat;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
+import androidx.core.content.ContextCompat;
+import androidx.core.app.ActivityCompat;
 
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static android.Manifest.permission.ACCESS_WIFI_STATE;

--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesPlaceFieldEnum.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesPlaceFieldEnum.java
@@ -1,7 +1,7 @@
 package com.arttitude360.reactnative.rngoogleplaces;
 
 import android.util.SparseArray;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.google.android.libraries.places.api.model.Place;
 

--- a/react-native-google-places.podspec
+++ b/react-native-google-places.podspec
@@ -21,4 +21,5 @@ Pod::Spec.new do |s|
   s.dependency 'React'
   s.dependency 'GooglePlaces', '~> 3.1.0'
   s.dependency 'GoogleMaps', '~> 3.1.0'
+  s.static_framework = true
 end


### PR DESCRIPTION
added s.static_framework = true
to avoid error:
target has transitive dependencies that include statically linked binaries: (/Users/vsts/agent/2.158.0/work/1/s/ios/Pods/GoogleMaps/Base/Frameworks/GoogleMapsBase.framework, /Users/vsts/agent/2.158.0/work/1/s/ios/Pods/GoogleMaps/Maps/Frameworks/GoogleMaps.framework, /Users/vsts/agent/2.158.0/work/1/s/ios/Pods/GoogleMaps/Maps/Frameworks/GoogleMapsCore.framework, and /Users/vsts/agent/2.158.0/work/1/s/ios/Pods/GooglePlaces/Frameworks/GooglePlaces.framework)