### PR TITLE
[Feature] Support session tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ build/Release
 node_modules
 npm-debug.log
 
+# Prettier
+.prettierignore
+
 # OSX
 #
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ end
 ##### 2) Configuration on iOS
 - In your `AppDelegate.m` file, import the Google Places library by adding 
 ```objectivec
-    @import GooglePlaces; 
-    @import GoogleMaps;
+@import GooglePlaces; 
+@import GoogleMaps;
 ```
 on top of the file.
 - Within the `didFinishLaunchingWithOptions` method, instantiate the library as follows - **read about a better way to secure this below**:
@@ -111,9 +111,9 @@ on top of the file.
 
 ```plist
 <key>NSLocationWhenInUseUsageDescription</key>
-	<string>RNGPDemos needs your location to show you places</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>RNGPDemos needs your location to show you places</string>
+<string>RNGPDemos needs your location to show you places</string>
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>RNGPDemos needs your location to show you places</string>
 ```
 
 
@@ -125,7 +125,6 @@ on top of the file.
 
 ```xml
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-
 <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 ```
 
@@ -224,9 +223,9 @@ class GPlacesDemo extends Component {
   openSearchModal() {
     RNGooglePlaces.openAutocompleteModal()
     .then((place) => {
-		console.log(place);
-		// place represents user's selection from the
-		// suggestions and it is a simplified Google Place object.
+      console.log(place);
+      // place represents user's selection from the
+      // suggestions and it is a simplified Google Place object.
     })
     .catch(error => console.log(error.message));  // error is a Javascript Error object
   }
@@ -250,22 +249,21 @@ class GPlacesDemo extends Component {
 To customize autocomplete results as listed for [Android](https://developers.google.com/places/android-sdk/autocomplete) and [iOS](https://developers.google.com/places/ios-sdk/autocomplete) in the official docs, you can pass an `options` object as a parameter to the `openAutocompleteModal()` method as follows:
 
 ```javascript
-    RNGooglePlaces.openAutocompleteModal({
-            initialQuery: 'vestar', 
-            locationRestriction: {
-                latitudeSW: 6.3670553, 
-                longitudeSW: 2.7062895, 
-                latitudeNE: 6.6967964, 
-                longitudeNE: 4.351055
-            },
-            country: 'NG',
-            type: 'establishment'
-        }, ['placeID', 'location', 'name', 'address', 'types', 'openingHours', 'plusCode', 'rating', 'userRatingsTotal', 'viewport']
-    )
-    .then((place) => {
-        console.log(place);
-    })
-    .catch(error => console.log(error.message));
+RNGooglePlaces.openAutocompleteModal({
+  initialQuery: 'vestar', 
+  locationRestriction: {
+    latitudeSW: 6.3670553, 
+    longitudeSW: 2.7062895, 
+    latitudeNE: 6.6967964, 
+    longitudeNE: 4.351055
+  },
+  country: 'NG',
+  type: 'establishment'
+}, [
+  'placeID', 'location', 'name', 'address', 'types', 'openingHours', 'plusCode', 'rating', 'userRatingsTotal', 'viewport'
+])
+.then((place) => console.log(place))
+.catch(error => console.log(error.message));
 ```
 **OPTIONS**
 - **`type`** _(String)_ - The type of results to return. Can only be one of (`geocode`, `address`, `establishment`, `regions`, and `cities`). *(optional)*
@@ -285,61 +283,54 @@ To customize autocomplete results as listed for [Android](https://developers.goo
 
 #### Example Response from the Autocomplete Modal
 ```javascript
-{   priceLevel: 0,
-    viewport: {   
-        longitudeSW: 3.320172219708498,
-        latitudeSW: 6.572546249999999,
-        longitudeNE: 3.322870180291502,
-        latitudeNE: 6.584909250000001 
-    },
-    address: 'Lagos, Nigeria',
-    location: {   
-        longitude: 3.3211348, 
-        latitude: 6.5818185 
-    },
-    addressComponents: [ 
-      { shortName: 'Lagos',
-        name: 'Lagos',
-        types: [ 'locality', 'political' ] 
-      },
-      { shortName: 'LA',
-        name: 'Lagos',
-        types: [ 'administrative_area_level_1', 'political' ] 
-      },
-      { shortName: 'NG',
-        name: 'Nigeria',
-        types: [ 'country', 'political' ] 
-      } 
-    ],
-    userRatingsTotal: 939,
-    plusCode: { 
-        globalCode: '6FR5H8JC+PF',
-        compoundCode: 'H8JC+PF Lagos, Nigeria' 
-    },
-    rating: 3.2,
-    types: [ 'airport', 'point_of_interest', 'establishment' ],
-    attributions: [],
-    placeID: 'ChIJhRTXUeeROxARmk_Rp3PtIvI',
-    name: 'Murtala Muhammed International Airport' 
+{
+  priceLevel: 0,
+  viewport: {   
+    longitudeSW: 3.320172219708498,
+    latitudeSW: 6.572546249999999,
+    longitudeNE: 3.322870180291502,
+    latitudeNE: 6.584909250000001 
+  },
+  address: 'Lagos, Nigeria',
+  location: {   
+    longitude: 3.3211348, 
+    latitude: 6.5818185 
+  },
+  addressComponents: [ 
+    { shortName: 'Lagos', name: 'Lagos', types: [ 'locality', 'political' ] },
+    { shortName: 'LA', name: 'Lagos', types: [ 'administrative_area_level_1', 'political' ] },
+    { shortName: 'NG', name: 'Nigeria', types: [ 'country', 'political' ] } 
+  ],
+  userRatingsTotal: 939,
+  plusCode: { 
+    globalCode: '6FR5H8JC+PF',
+    compoundCode: 'H8JC+PF Lagos, Nigeria' 
+  },
+  rating: 3.2,
+  types: [ 'airport', 'point_of_interest', 'establishment' ],
+  attributions: [],
+  placeID: 'ChIJhRTXUeeROxARmk_Rp3PtIvI',
+  name: 'Murtala Muhammed International Airport' 
 }
 ```
+
 - Note: The keys available from the response from the resolved `Promise` from calling `RNGooglePlaces.openAutocompleteModal()` are dependent on the selected place - as `phoneNumber, website, north, south, east, west, priceLevel, rating` are not set on all `Google Place` objects.
 
 ### Get Current Place
 This method returns to you the place where the device is currently located. That is, the place at the device's currently-reported location. For each place, the result includes an indication of the likelihood that the place is the right one. A higher value for `likelihood` means a greater probability that the place is the best match. Ensure you have required the appropriate permissions, as stated post-install steps above, before making this request.
 
 ```javascript
-  RNGooglePlaces.getCurrentPlace()
-    .then((results) => console.log(results))
-    .catch((error) => console.log(error.message));
+RNGooglePlaces.getCurrentPlace()
+.then((results) => console.log(results))
+.catch((error) => console.log(error.message));
 ```
 
 OR
 
 ```javascript
-  RNGooglePlaces.getCurrentPlace(['placeID', 'location', 'name', 'address'])
-    .then((results) => console.log(results))
-    .catch((error) => console.log(error.message));
+RNGooglePlaces.getCurrentPlace(['placeID', 'location', 'name', 'address'])
+.then((results) => console.log(results))
+.catch((error) => console.log(error.message));
 ```
 **PLACE FIELDS**
 - To prevent yourself from incurring huge usage bill, you can select the result fields you need in your application. Pass an *(optional)* `placeFields` as the only param to `getCurrentPlace`.
@@ -350,7 +341,8 @@ OR
 #### Example Response from Calling getCurrentPlace()
 
 ```javascript
-[{ name: 'Facebook HQ',
+[{ 
+  name: 'Facebook HQ',
   website: 'https://www.facebook.com/',
   longitude: -122.14835169999999,
   address: '1 Hacker Way, Menlo Park, CA 94025, USA',
@@ -388,8 +380,8 @@ RNGooglePlaces.beginAutocompleteSession();
 
 // You might call this several times (as the user is typing his query)
 RNGooglePlaces.getAutocompletePredictions('facebook')
-  .then((results) => this.setState({ predictions: results }))
-  .catch((error) => console.log(error.message));
+.then((results) => this.setState({ predictions: results }))
+.catch((error) => console.log(error.message));
 
 // Lookup a place by its ID
 RNGooglePlaces.lookUpPlaceByID('ChIJZa6ezJa8j4AR1p1nTSaRtuQ');
@@ -456,19 +448,19 @@ RNGooglePlaces.getAutocompletePredictions('pizza', {
 #### Example Response from Calling getAutocompletePredictions()
 
 ```javascript
-[ { primaryText: 'Facebook HQ',
-    placeID: 'ChIJZa6ezJa8j4AR1p1nTSaRtuQ',
-    secondaryText: 'Hacker Way, Menlo Park, CA, United States',
-    fullText: 'Facebook HQ, Hacker Way, Menlo Park, CA, United States' },
-    types: [ 'street_address', 'geocode' ],
-  { primaryText: 'Facebook Way',
-    placeID: 'EitGYWNlYm9vayBXYXksIE1lbmxvIFBhcmssIENBLCBVbml0ZWQgU3RhdGVz',
-    secondaryText: 'Menlo Park, CA, United States',
-    fullText: 'Facebook Way, Menlo Park, CA, United States' },
-    types: [ 'street_address', 'geocode' ],
-
-    ...
-]
+[{ 
+  primaryText: 'Facebook HQ',
+  placeID: 'ChIJZa6ezJa8j4AR1p1nTSaRtuQ',
+  secondaryText: 'Hacker Way, Menlo Park, CA, United States',
+  fullText: 'Facebook HQ, Hacker Way, Menlo Park, CA, United States',
+  types: [ 'street_address', 'geocode' ]
+}, { 
+  primaryText: 'Facebook Way',
+  placeID: 'EitGYWNlYm9vayBXYXksIE1lbmxvIFBhcmssIENBLCBVbml0ZWQgU3RhdGVz',
+  secondaryText: 'Menlo Park, CA, United States',
+  fullText: 'Facebook Way, Menlo Park, CA, United States',
+  types: [ 'street_address', 'geocode' ]
+}]
 ```
 
 #### Look-Up Place By ID
@@ -495,7 +487,8 @@ RNGooglePlaces.lookUpPlaceByID('ChIJZa6ezJa8j4AR1p1nTSaRtuQ', ['placeID', 'locat
 #### Example Response from Calling lookUpPlaceByID()
 
 ```javascript
-{ name: 'Facebook HQ',
+{ 
+  name: 'Facebook HQ',
   website: 'https://www.facebook.com/',
   longitude: -122.14835169999999,
   address: '1 Hacker Way, Menlo Park, CA 94025, USA',

--- a/README.md
+++ b/README.md
@@ -370,43 +370,77 @@ The sum of the likelihoods in a given result set is always less than or equal to
 ### Using Your Own Custom UI/Views
 If you have specific branding needs or you would rather build out your own custom search input and suggestions list (think `Uber`), you may profit from calling the API methods below which would get you autocomplete predictions programmatically using the underlying `iOS and Android SDKs`.
 
+#### Session Tokens (and why you should care)
+
+Recommended read: 
+* [Places API - Session Tokens](https://developers.google.com/places/web-service/session-tokens)
+* [Places API - Usage and Billing](https://developers.google.com/places/web-service/usage-and-billing)
+
+Calling the following methods (`getAutocompletePredictions` and `lookUpPlaceByID`) without a session token can result in unwanted expensive bills from Google. This happens because the Places APIs are billed by SKU. Usage is tracked for each Product SKU, and an API may have more than one Product SKU (more on the **Usage and Billing** link above).
+
+This module exposes a function named `beginAutocompleteSession` that once invoked will generate a **Session Token** on the module instance. This Session Token will be reused for each subsequent `getAutocompletePredictions` and `lookUpPlaceByID` calls. As of October 2019, Session Tokens **MUST** be renewed upon calling `lookUpPlaceByID`, as this API call marks the "end" of a session for billing purposes. **FORGETTING TO GENERATE A NEW SESSION TOKEN AFTER CALLING `lookupPlaceById` CAN INCREASE YOUR BILL**. 
+
+Example of how an Autocomplete Session would look like:
+
+```javascript
+// Generate session token
+RNGooglePlaces.beginAutocompleteSession();
+
+// You might call this several times (as the user is typing his query)
+RNGooglePlaces.getAutocompletePredictions('facebook')
+  .then((results) => this.setState({ predictions: results }))
+  .catch((error) => console.log(error.message));
+
+// Lookup a place by its ID
+RNGooglePlaces.lookUpPlaceByID('ChIJZa6ezJa8j4AR1p1nTSaRtuQ');
+
+// Generate new session token in case your user cancels his selection and wants to continue searching
+RNGooglePlaces.beginAutocompleteSession();
+```
+
+In case you want to make Places API calls without using a session token, a function named `cancelAutocompleteSession` is also exposed. Invoking it will erase an existing Session Token.
+
+```javascript
+RNGooglePlaces.cancelAutocompleteSession();
+```
+
 #### Get Autocomplete Predictions
 
 ```javascript
-  RNGooglePlaces.getAutocompletePredictions('facebook')
-    .then((results) => this.setState({ predictions: results }))
-    .catch((error) => console.log(error.message));
+RNGooglePlaces.getAutocompletePredictions('facebook')
+.then((results) => this.setState({ predictions: results }))
+.catch((error) => console.log(error.message));
 ```
 
 ##### **Optional Parameters**
 To filter autocomplete results as listed for [Android](https://developers.google.com/places/android-api/autocomplete#restrict_autocomplete_results) and [iOS](https://developers.google.com/places/ios-api/autocomplete#call_gmsplacesclient) in the official docs, you can pass an `options` object as a second parameter to the `getAutocompletePredictions()` method as follows:
 
 ```javascript
-  RNGooglePlaces.getAutocompletePredictions('Lagos', {
-	  type: 'cities',
-	  country: 'NG'
-  })
-    .then((place) => {
-    console.log(place);
-    })
-    .catch(error => console.log(error.message));
+RNGooglePlaces.getAutocompletePredictions('Lagos', {
+  type: 'cities',
+  country: 'NG'
+})
+.then((place) => {
+  console.log(place);
+})
+.catch(error => console.log(error.message));
 ```
 OR
 
 ```javascript
 RNGooglePlaces.getAutocompletePredictions('pizza', {
-	    type: 'establishments',
-	    locationBias: {
-            latitudeSW: 6.3670553, 
-            longitudeSW: 2.7062895, 
-            latitudeNE: 6.6967964, 
-            longitudeNE: 4.351055
-        }
-    })
-    .then((place) => {
-    console.log(place);
-    })
-    .catch(error => console.log(error.message));
+  type: 'establishments',
+  locationBias: {
+    latitudeSW: 6.3670553, 
+    longitudeSW: 2.7062895, 
+    latitudeNE: 6.6967964, 
+    longitudeNE: 4.351055
+  }
+})
+.then((place) => {
+  console.log(place);
+})
+.catch(error => console.log(error.message));
 ```
 
 
@@ -440,16 +474,16 @@ RNGooglePlaces.getAutocompletePredictions('pizza', {
 #### Look-Up Place By ID
 
 ```javascript
-  RNGooglePlaces.lookUpPlaceByID('ChIJZa6ezJa8j4AR1p1nTSaRtuQ')
-    .then((results) => console.log(results))
-    .catch((error) => console.log(error.message));
+RNGooglePlaces.lookUpPlaceByID('ChIJZa6ezJa8j4AR1p1nTSaRtuQ')
+.then((results) => console.log(results))
+.catch((error) => console.log(error.message));
 ```
 OR
 
 ```javascript
-  RNGooglePlaces.lookUpPlaceByID('ChIJZa6ezJa8j4AR1p1nTSaRtuQ', ['placeID', 'location', 'name', 'address'])
-    .then((results) => console.log(results))
-    .catch((error) => console.log(error.message));
+RNGooglePlaces.lookUpPlaceByID('ChIJZa6ezJa8j4AR1p1nTSaRtuQ', ['placeID', 'location', 'name', 'address'])
+.then((results) => console.log(results))
+.catch((error) => console.log(error.message));
 ```
 
 

--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
@@ -123,8 +123,13 @@ public class RNGooglePlacesModule extends ReactContextBaseJavaModule implements 
      */
 
     @ReactMethod
-    public void beginNewAutocompleteSession() {
+    public void beginAutocompleteSession() {
         sessionToken = AutocompleteSessionToken.newInstance();
+    }
+
+    @ReactMethod
+    public void cancelAutocompleteSession() {
+        sessionToken = null;
     }
 
     @ReactMethod
@@ -309,7 +314,7 @@ public class RNGooglePlacesModule extends ReactContextBaseJavaModule implements 
             promise.resolve(map);
         }).addOnFailureListener((exception) -> {
             promise.reject("E_PLACE_DETAILS_ERROR", new Error(exception.getMessage()));
-        }).addOnCompleteListener((exception) -> beginNewAutocompleteSession());
+        });
     }
 
     @ReactMethod

--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ class RNGooglePlaces {
 	getCurrentPlace(placeFields = []) {
 		return RNGooglePlacesNative.getCurrentPlace([...RNGooglePlaces.placeFieldsDefaults, ...placeFields])
 	}
+
+	beginNewAutocompleteSession() {
+        return RNGooglePlacesNative.beginNewAutocompleteSession();
+    }
 }
 
 export default new RNGooglePlaces()

--- a/index.js
+++ b/index.js
@@ -50,8 +50,12 @@ class RNGooglePlaces {
 		return RNGooglePlacesNative.getCurrentPlace([...RNGooglePlaces.placeFieldsDefaults, ...placeFields])
 	}
 
-	beginNewAutocompleteSession() {
-        return RNGooglePlacesNative.beginNewAutocompleteSession();
+	beginAutocompleteSession() {
+        return RNGooglePlacesNative.beginAutocompleteSession();
+	}
+	
+	cancelAutocompleteSession() {
+        return RNGooglePlacesNative.cancelAutocompleteSession();
     }
 }
 

--- a/ios/RNGooglePlaces.m
+++ b/ios/RNGooglePlaces.m
@@ -14,6 +14,7 @@
 
 @property (strong, nonatomic) CLLocationManager *locationManager;
 @property GMSAutocompleteBoundsMode boundsMode;
+@property GMSAutocompleteSessionToken *sessionToken;
 
 @end
 
@@ -52,17 +53,22 @@ RCT_EXPORT_MODULE()
     self.locationManager = nil;
 }
 
-RCT_EXPORT_METHOD(openAutocompleteModal: (NSDictionary *)options
-                    withFields: (NSArray *)fields
-                    resolver: (RCTPromiseResolveBlock)resolve
-                    rejecter: (RCTPromiseRejectBlock)reject)
+- (void)beginNewAutocompleteSession
 {
+    self.sessionToken = [[GMSAutocompleteSessionToken alloc] init];
+}
 
+RCT_EXPORT_METHOD(openAutocompleteModal: (NSDictionary *)options
+                  withFields: (NSArray *)fields
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject)
+{
+    
     @try {
         RNGooglePlacesViewController* acController = [[RNGooglePlacesViewController alloc] init];
-
+        
         GMSPlaceField selectedFields = [self getSelectedFields:fields isCurrentOrFetchPlace:false];
-
+        
         GMSAutocompleteFilter *autocompleteFilter = [[GMSAutocompleteFilter alloc] init];
         autocompleteFilter.type = [self getFilterType:[RCTConvert NSString:options[@"type"]]];
         autocompleteFilter.country = [options[@"country"] length] == 0? nil : options[@"country"];
@@ -72,13 +78,15 @@ RCT_EXPORT_METHOD(openAutocompleteModal: (NSDictionary *)options
         
         
         GMSCoordinateBounds *autocompleteBounds = [self getBounds:locationBias andRestrictOptions:locationRestriction];
-
+        
         [acController openAutocompleteModal: autocompleteFilter placeFields: selectedFields bounds: autocompleteBounds boundsMode: self.boundsMode resolver: resolve rejecter: reject];
     }
     @catch (NSException * e) {
         reject(@"E_OPEN_FAILED", @"Could not open modal", [self errorFromException:e]);
     }
 }
+
+RCT_EXTERN_METHOD(beginNewAutocompleteSession);
 
 RCT_EXPORT_METHOD(getAutocompletePredictions: (NSString *)query
                   filterOptions: (NSDictionary *)options
@@ -95,87 +103,87 @@ RCT_EXPORT_METHOD(getAutocompletePredictions: (NSString *)query
     
     GMSCoordinateBounds *autocompleteBounds = [self getBounds:locationBias andRestrictOptions:locationRestriction];
     
-    GMSAutocompleteSessionToken *token = [[GMSAutocompleteSessionToken alloc] init];
-    
     [[GMSPlacesClient sharedClient] findAutocompletePredictionsFromQuery:query
-                                               bounds:autocompleteBounds
-                                               boundsMode:self.boundsMode
-                                               filter:autocompleteFilter
-                                               sessionToken:token
-                                             callback:^(NSArray<GMSAutocompletePrediction *> * _Nullable results, NSError *error) {
-                                                 if (error != nil) {
-                                                     reject(@"E_AUTOCOMPLETE_ERROR", [error description], nil);
-                                                     return;
-                                                 }
-
-                                                 if (results != nil) {
-                                                    for (GMSAutocompletePrediction* result in results) {
-                                                        NSMutableDictionary *placeData = [[NSMutableDictionary alloc] init];
-                                                        
-                                                        placeData[@"fullText"] = result.attributedFullText.string;
-                                                        placeData[@"primaryText"] = result.attributedPrimaryText.string;
-                                                        placeData[@"secondaryText"] = result.attributedSecondaryText.string;
-                                                        placeData[@"placeID"] = result.placeID;
-                                                        placeData[@"types"] = result.types;
-                                                        
-                                                        [autoCompleteSuggestionsList addObject:placeData];
-                                                    }
-                                                    
-                                                    resolve(autoCompleteSuggestionsList);
-
-                                                 }
-                                                 
-                                             }];
+                                                                  bounds:autocompleteBounds
+                                                              boundsMode:self.boundsMode
+                                                                  filter:autocompleteFilter
+                                                            sessionToken:self.sessionToken
+                                                                callback:^(NSArray<GMSAutocompletePrediction *> * _Nullable results, NSError *error) {
+                                                                    if (error != nil) {
+                                                                        reject(@"E_AUTOCOMPLETE_ERROR", [error description], nil);
+                                                                        return;
+                                                                    }
+                                                                    
+                                                                    if (results != nil) {
+                                                                        for (GMSAutocompletePrediction* result in results) {
+                                                                            NSMutableDictionary *placeData = [[NSMutableDictionary alloc] init];
+                                                                            
+                                                                            placeData[@"fullText"] = result.attributedFullText.string;
+                                                                            placeData[@"primaryText"] = result.attributedPrimaryText.string;
+                                                                            placeData[@"secondaryText"] = result.attributedSecondaryText.string;
+                                                                            placeData[@"placeID"] = result.placeID;
+                                                                            placeData[@"types"] = result.types;
+                                                                            
+                                                                            [autoCompleteSuggestionsList addObject:placeData];
+                                                                        }
+                                                                        
+                                                                        resolve(autoCompleteSuggestionsList);
+                                                                        
+                                                                    }
+                                                                    
+                                                                }];
 }
 
 RCT_EXPORT_METHOD(lookUpPlaceByID: (NSString*)placeID
-                 withFields: (NSArray *)fields
-                 resolver: (RCTPromiseResolveBlock)resolve
-                 rejecter: (RCTPromiseRejectBlock)reject)
+                  withFields: (NSArray *)fields
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject)
 {
     GMSPlaceField selectedFields = [self getSelectedFields:fields isCurrentOrFetchPlace:false];
+    
+    [[GMSPlacesClient sharedClient] fetchPlaceFromPlaceID:placeID placeFields:selectedFields sessionToken:self.sessionToken
+                                                 callback:^(GMSPlace * _Nullable place, NSError * _Nullable error) {
+                                                     [self beginNewAutocompleteSession];
 
-    [[GMSPlacesClient sharedClient] fetchPlaceFromPlaceID:placeID placeFields:selectedFields sessionToken:nil
-                                         callback:^(GMSPlace * _Nullable place, NSError * _Nullable error) {
-                                             if (error != nil) {
-                                                 reject(@"E_PLACE_DETAILS_ERROR", [error localizedDescription], nil);
-                                                 return;
-                                             }
-                                             
-                                             if (place != nil) {
-                                                 resolve([NSMutableDictionary dictionaryWithGMSPlace:place]);
-                                             } else {
-                                                 resolve(@{});
-                                             }
-                                         }];
+                                                     if (error != nil) {
+                                                         reject(@"E_PLACE_DETAILS_ERROR", [error localizedDescription], nil);
+                                                         return;
+                                                     }
+                                                     
+                                                     if (place != nil) {
+                                                         resolve([NSMutableDictionary dictionaryWithGMSPlace:place]);
+                                                     } else {
+                                                         resolve(@{});
+                                                     }
+                                                 }];
 }
 
 RCT_EXPORT_METHOD(getCurrentPlace: (NSArray *)fields
-                                    resolver: (RCTPromiseResolveBlock)resolve
-                                    rejecter: (RCTPromiseRejectBlock)reject)
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject)
 {
     [self.locationManager requestAlwaysAuthorization];
     
-
+    
     GMSPlaceField selectedFields = [self getSelectedFields:fields isCurrentOrFetchPlace:true];
-
+    
     NSMutableArray *likelyPlacesList = [NSMutableArray array];
-
+    
     [[GMSPlacesClient sharedClient] findPlaceLikelihoodsFromCurrentLocationWithPlaceFields:selectedFields callback:^(NSArray<GMSPlaceLikelihood *> * _Nullable likelihoods, NSError * _Nullable error) {
         if (error != nil) {
             reject(@"E_CURRENT_PLACE_ERROR", [error localizedDescription], nil);
             return;
         }
-
+        
         if (likelihoods != nil) {
             for (GMSPlaceLikelihood *likelihood in likelihoods) {
                 NSMutableDictionary *placeData = [NSMutableDictionary dictionaryWithGMSPlace:likelihood.place];
                 placeData[@"likelihood"] = [NSNumber numberWithDouble:likelihood.likelihood];
-
+                
                 [likelyPlacesList addObject:placeData];
             }
         }
-
+        
         resolve(likelyPlacesList);
     }];
 }
@@ -215,27 +223,27 @@ RCT_EXPORT_METHOD(getCurrentPlace: (NSArray *)fields
 - (GMSPlaceField) getSelectedFields:(NSArray *)fields isCurrentOrFetchPlace:(Boolean)currentOrFetch
 {
     NSDictionary *fieldsMapping = @{
-        @"name" : @(GMSPlaceFieldName),
-        @"placeID" : @(GMSPlaceFieldPlaceID),
-        @"plusCode" : @(GMSPlaceFieldPlusCode),
-        @"location" : @(GMSPlaceFieldCoordinate),
-        @"openingHours" : @(GMSPlaceFieldOpeningHours),
-        @"phoneNumber" : @(GMSPlaceFieldPhoneNumber),
-        @"address" : @(GMSPlaceFieldFormattedAddress),
-        @"rating" : @(GMSPlaceFieldRating),
-        @"userRatingsTotal" : @(GMSPlaceFieldUserRatingsTotal),
-        @"priceLevel" : @(GMSPlaceFieldPriceLevel),
-        @"types" : @(GMSPlaceFieldTypes),
-        @"website" : @(GMSPlaceFieldWebsite),
-        @"viewport" : @(GMSPlaceFieldViewport),
-        @"addressComponents" : @(GMSPlaceFieldAddressComponents),
-        @"photos" : @(GMSPlaceFieldPhotos),
-    };
+                                    @"name" : @(GMSPlaceFieldName),
+                                    @"placeID" : @(GMSPlaceFieldPlaceID),
+                                    @"plusCode" : @(GMSPlaceFieldPlusCode),
+                                    @"location" : @(GMSPlaceFieldCoordinate),
+                                    @"openingHours" : @(GMSPlaceFieldOpeningHours),
+                                    @"phoneNumber" : @(GMSPlaceFieldPhoneNumber),
+                                    @"address" : @(GMSPlaceFieldFormattedAddress),
+                                    @"rating" : @(GMSPlaceFieldRating),
+                                    @"userRatingsTotal" : @(GMSPlaceFieldUserRatingsTotal),
+                                    @"priceLevel" : @(GMSPlaceFieldPriceLevel),
+                                    @"types" : @(GMSPlaceFieldTypes),
+                                    @"website" : @(GMSPlaceFieldWebsite),
+                                    @"viewport" : @(GMSPlaceFieldViewport),
+                                    @"addressComponents" : @(GMSPlaceFieldAddressComponents),
+                                    @"photos" : @(GMSPlaceFieldPhotos),
+                                    };
     
     if ([fields count] == 0 && !currentOrFetch) {
         return GMSPlaceFieldAll;
     }
-
+    
     if ([fields count] == 0 && currentOrFetch) {
         GMSPlaceField placeFields = 0;
         for (NSString *fieldLabel in fieldsMapping) {
@@ -248,7 +256,7 @@ RCT_EXPORT_METHOD(getCurrentPlace: (NSArray *)fields
         }
         return placeFields;
     }
-
+    
     if ([fields count] != 0 && currentOrFetch) {
         GMSPlaceField placeFields = 0;
         for (NSString *fieldLabel in fields) {
@@ -261,7 +269,7 @@ RCT_EXPORT_METHOD(getCurrentPlace: (NSArray *)fields
         }
         return placeFields;
     }
-
+    
     if ([fields count] != 0 && !currentOrFetch) {
         GMSPlaceField placeFields = 0;
         for (NSString *fieldLabel in fields) {
@@ -279,26 +287,26 @@ RCT_EXPORT_METHOD(getCurrentPlace: (NSArray *)fields
     double biasLongitudeSW = [[RCTConvert NSNumber:biasOptions[@"longitudeSW"]] doubleValue];
     double biasLatitudeNE = [[RCTConvert NSNumber:biasOptions[@"latitudeNE"]] doubleValue];
     double biasLongitudeNE = [[RCTConvert NSNumber:biasOptions[@"longitudeNE"]] doubleValue];
-
+    
     double restrictLatitudeSW = [[RCTConvert NSNumber:restrictOptions[@"latitudeSW"]] doubleValue];
     double restrictLongitudeSW = [[RCTConvert NSNumber:restrictOptions[@"longitudeSW"]] doubleValue];
     double restrictLatitudeNE = [[RCTConvert NSNumber:restrictOptions[@"latitudeNE"]] doubleValue];
     double restrictLongitudeNE = [[RCTConvert NSNumber:restrictOptions[@"longitudeNE"]] doubleValue];
-
+    
     if (biasLatitudeSW != 0 && biasLongitudeSW != 0 && biasLatitudeNE != 0 && biasLongitudeNE != 0) {
         CLLocationCoordinate2D neBoundsCorner = CLLocationCoordinate2DMake(biasLatitudeNE, biasLongitudeNE);
         CLLocationCoordinate2D swBoundsCorner = CLLocationCoordinate2DMake(biasLatitudeSW, biasLongitudeSW);
         GMSCoordinateBounds *bounds = [[GMSCoordinateBounds alloc] initWithCoordinate:neBoundsCorner
-                                                                        coordinate:swBoundsCorner];
-
+                                                                           coordinate:swBoundsCorner];
+        
         return bounds;
-    }  
-
+    }
+    
     if (restrictLatitudeSW != 0 && restrictLongitudeSW != 0 && restrictLatitudeNE != 0 && restrictLongitudeNE != 0) {
         CLLocationCoordinate2D neBoundsCorner = CLLocationCoordinate2DMake(restrictLatitudeNE, restrictLongitudeNE);
         CLLocationCoordinate2D swBoundsCorner = CLLocationCoordinate2DMake(restrictLatitudeSW, restrictLongitudeSW);
         GMSCoordinateBounds *bounds = [[GMSCoordinateBounds alloc] initWithCoordinate:neBoundsCorner
-                                                                        coordinate:swBoundsCorner];
+                                                                           coordinate:swBoundsCorner];
         
         self.boundsMode = kGMSAutocompleteBoundsModeRestrict;
         

--- a/ios/RNGooglePlaces.m
+++ b/ios/RNGooglePlaces.m
@@ -53,10 +53,18 @@ RCT_EXPORT_MODULE()
     self.locationManager = nil;
 }
 
-- (void)beginNewAutocompleteSession
+RCT_EXTERN_METHOD(beginAutocompleteSession);
+- (void)beginAutocompleteSession
 {
-    self.sessionToken = [[GMSAutocompleteSessionToken alloc] init];
+    self.sessionToken = [GMSAutocompleteSessionToken new];
 }
+
+RCT_EXTERN_METHOD(cancelAutocompleteSession);
+- (void)cancelAutocompleteSession
+{
+    self.sessionToken = nil;
+}
+
 
 RCT_EXPORT_METHOD(openAutocompleteModal: (NSDictionary *)options
                   withFields: (NSArray *)fields
@@ -85,8 +93,6 @@ RCT_EXPORT_METHOD(openAutocompleteModal: (NSDictionary *)options
         reject(@"E_OPEN_FAILED", @"Could not open modal", [self errorFromException:e]);
     }
 }
-
-RCT_EXTERN_METHOD(beginNewAutocompleteSession);
 
 RCT_EXPORT_METHOD(getAutocompletePredictions: (NSString *)query
                   filterOptions: (NSDictionary *)options
@@ -143,8 +149,6 @@ RCT_EXPORT_METHOD(lookUpPlaceByID: (NSString*)placeID
     
     [[GMSPlacesClient sharedClient] fetchPlaceFromPlaceID:placeID placeFields:selectedFields sessionToken:self.sessionToken
                                                  callback:^(GMSPlace * _Nullable place, NSError * _Nullable error) {
-                                                     [self beginNewAutocompleteSession];
-
                                                      if (error != nil) {
                                                          reject(@"E_PLACE_DETAILS_ERROR", [error localizedDescription], nil);
                                                          return;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "iOS/Android Google Places Widgets (Autocomplete Modals) and API Services for React Native Apps",
   "main": "index.js",
   "author": "Tolu Olowu (Arttitude 360) <tolu@arttitude360.com>",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "scripts": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
One of the apps I currently maintain has been severely affected by the Places API price changes introduced this year. Overnight my client saw his Google Places bill increase by ~10x, and upon investigating a bit further I came to the conclusion that the lack of support for session tokens on this module was the cause for this price increase. I do not use the provided Autocomplete Modal, so I'm not the right person to tell whether it correctly uses session tokens or not. This pull request only addresses the scenario where an app is making multiple `getAutocompletePredictions` calls, optionally followed by a `lookUpPlaceByID` call.

This pull request fixes this issue by exposing a new function named `beginAutocompleteSession` that generates a new Session Token on the module's class instance. Further calls to `getAutocompletePredictions` and `lookUpPlaceByID` will then use this Session Token. There's also a new function `cancelAutocompleteSession` that does the opposite - cleans up any session tokens being kept on the module's class instance.

I'm keen to discuss better ways to implement this as well.

Read more: 
[Places API - Session Tokens](https://developers.google.com/places/web-service/session-tokens)
[SKU: Autocomplete (included with Places Details) – Per Session](https://developers.google.com/places/web-service/usage-and-billing#ac-with-details-session)
