### PR TITLE
Use viewportInfo instead of viewport

### DIFF
--- a/ios/NSMutableDictionary+GMSPlace.m
+++ b/ios/NSMutableDictionary+GMSPlace.m
@@ -48,15 +48,15 @@
         placeData[@"rating"] = [NSNumber numberWithDouble:place.rating];
     }
     
-    if (place.viewport) {
-        NSMutableDictionary *viewportMap = [[NSMutableDictionary alloc] init];
-        viewportMap[@"latitudeNE"] = [NSNumber numberWithDouble:place.viewport.northEast.latitude];
-        viewportMap[@"longitudeNE"] = [NSNumber numberWithDouble:place.viewport.northEast.longitude];
-        viewportMap[@"latitudeSW"] = [NSNumber numberWithDouble:place.viewport.southWest.latitude];
-        viewportMap[@"longitudeSW"] = [NSNumber numberWithDouble:place.viewport.southWest.longitude];
+  if (place.viewportInfo) {
+       NSMutableDictionary *viewportMap = [[NSMutableDictionary alloc] init];
+       viewportMap[@"latitudeNE"] = [NSNumber numberWithDouble:place.viewportInfo.northEast.latitude];
+       viewportMap[@"longitudeNE"] = [NSNumber numberWithDouble:place.viewportInfo.northEast.longitude];
+       viewportMap[@"latitudeSW"] = [NSNumber numberWithDouble:place.viewportInfo.southWest.latitude];
+       viewportMap[@"longitudeSW"] = [NSNumber numberWithDouble:place.viewportInfo.southWest.longitude];
 
-        placeData[@"viewport"] = viewportMap;
-    }
+       placeData[@"viewport"] = viewportMap;
+   }
 
     if (place.plusCode) {
         NSMutableDictionary *plusCodeMap = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
[Places SDKs for iOS will no longer support the viewport property of GMSPlace objects.](https://github.com/tolu360/react-native-google-places/issues/293#issue-835946815)

Starting with version 5.0 of the Google Maps Platform Places SDK for iOS, the viewport property of GMSPlace objects will be replaced with a property named viewportInfo of a new class type.

#293 